### PR TITLE
django: add http download server feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ compliance.xml
 GitDiffCheck.txt
 Gitlint.txt
 
+# Firmware folder
+firmware/
+
 # Database files
 *.sqlite3
 


### PR DESCRIPTION
This is the first step towards implementing OTA updates:

Added the option to upload a file and register it to the firmware table.
    
- Check filesize (max 1 MB)
- Remove explicit name and download field as it is redundant
- Firmware Version has to be unique
- Support for multiple files with identical name. This allows to choose a binary file like 'merged.bin' for several version. Django automatically adds a unique string 'merged_Y7WrC6M.elf' to distinguish between files. The download link is the file with the unique string.

Example download link:  https://flownexus.org:8000/media/firmware/v0.1.0_Y7WrC6M.bin