### PR TITLE
Add firmware to the list in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ compliance.xml
 GitDiffCheck.txt
 Gitlint.txt
 
+# Firmware folder
+firmware/
+
 # Database files
 *.sqlite3
 


### PR DESCRIPTION
This commit adds the firmware folder to the list of files to ignore in the .gitignore file.