### PR TITLE
django: fix django url in settings

### DIFF
--- a/server/django/server/settings.py
+++ b/server/django/server/settings.py
@@ -30,7 +30,7 @@ SECRET_KEY = "django-insecure-ttm_sr56l7mv#4smgm*+tffm*$q%!qqp@#q7*_*y38^^#9%@7*
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-CSRF_TRUSTED_ORIGINS = ['https://flownexus.org', 'http://www.flownexus.org']
+CSRF_TRUSTED_ORIGINS = ['https://flownexus.org', 'https://www.flownexus.org']
 
 LOGGING = {
     'version': 1,


### PR DESCRIPTION
After fixing #52 I still noticed that sometimes flownexus does not load after login. The reason was an error in the URL. The Flownexus webinterface is only available via https.